### PR TITLE
dramasテーブルのtitleカラムに一意制約を追加

### DIFF
--- a/src/main/java/com/raisetech/drama/controller/CustomExceptionHandler.java
+++ b/src/main/java/com/raisetech/drama/controller/CustomExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.raisetech.drama.controller;
 
+import com.raisetech.drama.exception.DuplicateTitleException;
 import com.raisetech.drama.exception.ResourceNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
@@ -61,5 +62,16 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler{
                 "error", HttpStatus.BAD_REQUEST.getReasonPhrase());
         return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
         }
+
+    @ExceptionHandler(value = DuplicateTitleException.class)
+    public ResponseEntity<Map<String, String>> handleDuplicateTitleException(
+            DuplicateTitleException ex, HttpServletRequest request) {
+        Map<String, String> body = Map.of(
+                "timeStamp", ZonedDateTime.now().toString(),
+                "message", ex.getMessage(),
+                "status", String.valueOf(HttpStatus.CONFLICT.value()),
+                "error", HttpStatus.CONFLICT.getReasonPhrase());
+        return new ResponseEntity(body, HttpStatus.CONFLICT);
+    }
 
 }

--- a/src/main/java/com/raisetech/drama/exception/DuplicateTitleException.java
+++ b/src/main/java/com/raisetech/drama/exception/DuplicateTitleException.java
@@ -1,0 +1,19 @@
+package com.raisetech.drama.exception;
+
+public class DuplicateTitleException extends RuntimeException {
+    public DuplicateTitleException() {
+        super();
+    }
+
+    public DuplicateTitleException(String message) {
+        super(message);
+    }
+
+    public DuplicateTitleException(Throwable cause) {
+        super(cause);
+    }
+
+    public DuplicateTitleException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/raisetech/drama/mapper/DramasMapper.java
+++ b/src/main/java/com/raisetech/drama/mapper/DramasMapper.java
@@ -33,4 +33,8 @@ public interface DramasMapper {
             + "WHERE id = #{id}")
     void update(Drama drama);
 
+    @Update("UPDATE IGNORE dramas SET title = #{title}, year = #{year}, priority = #{priority} "
+            + "WHERE id = #{id}")
+    void updateDramaIgnoreDuplicates(Drama drama);
+
 }

--- a/src/main/java/com/raisetech/drama/mapper/DramasMapper.java
+++ b/src/main/java/com/raisetech/drama/mapper/DramasMapper.java
@@ -26,15 +26,8 @@ public interface DramasMapper {
     @Options(useGeneratedKeys = true, keyProperty = "id")
     void save(DramaDto dramaDto);
 
-    @Insert("INSERT IGNORE INTO dramas (title, year, priority) VALUES (#{title}, #{year}, #{priority})")
-    void saveDramaIgnoreDuplicates(DramaDto dramaDto);
-
     @Update("UPDATE dramas SET title = #{title}, year = #{year}, priority = #{priority} "
             + "WHERE id = #{id}")
     void update(Drama drama);
-
-    @Update("UPDATE IGNORE dramas SET title = #{title}, year = #{year}, priority = #{priority} "
-            + "WHERE id = #{id}")
-    void updateDramaIgnoreDuplicates(Drama drama);
 
 }

--- a/src/main/java/com/raisetech/drama/mapper/DramasMapper.java
+++ b/src/main/java/com/raisetech/drama/mapper/DramasMapper.java
@@ -26,6 +26,9 @@ public interface DramasMapper {
     @Options(useGeneratedKeys = true, keyProperty = "id")
     void save(DramaDto dramaDto);
 
+    @Insert("INSERT IGNORE INTO dramas (title, year, priority) VALUES (#{title}, #{year}, #{priority})")
+    void saveDramaIgnoreDuplicates(DramaDto dramaDto);
+
     @Update("UPDATE dramas SET title = #{title}, year = #{year}, priority = #{priority} "
             + "WHERE id = #{id}")
     void update(Drama drama);

--- a/src/main/java/com/raisetech/drama/service/DramasServiceImpl.java
+++ b/src/main/java/com/raisetech/drama/service/DramasServiceImpl.java
@@ -2,8 +2,10 @@ package com.raisetech.drama.service;
 
 import com.raisetech.drama.dto.DramaDto;
 import com.raisetech.drama.entity.Drama;
+import com.raisetech.drama.exception.DuplicateTitleException;
 import com.raisetech.drama.exception.ResourceNotFoundException;
 import com.raisetech.drama.mapper.DramasMapper;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -25,9 +27,15 @@ public class DramasServiceImpl implements DramasService{
     public List<Drama> getAllDramas(){
         return dramasMapper.findAll().stream().toList();
     }
+
     @Override
     public int save(DramaDto dramaDto) {
-        dramasMapper.save(dramaDto);
+        try {
+            dramasMapper.save(dramaDto);
+        } catch (DuplicateKeyException e) {
+            dramasMapper.saveDramaIgnoreDuplicates(dramaDto);
+            throw new DuplicateTitleException(dramaDto.getTitle() + "は、すでに登録されています。");
+        }
         return dramaDto.getId();
     }
 

--- a/src/main/java/com/raisetech/drama/service/DramasServiceImpl.java
+++ b/src/main/java/com/raisetech/drama/service/DramasServiceImpl.java
@@ -33,7 +33,6 @@ public class DramasServiceImpl implements DramasService{
         try {
             dramasMapper.save(dramaDto);
         } catch (DuplicateKeyException e) {
-            dramasMapper.saveDramaIgnoreDuplicates(dramaDto);
             throw new DuplicateTitleException(dramaDto.getTitle() + "は、すでに登録されています。");
         }
         return dramaDto.getId();
@@ -55,7 +54,6 @@ public class DramasServiceImpl implements DramasService{
         try {
             dramasMapper.update(drama);
         } catch (DuplicateKeyException e) {
-            dramasMapper.updateDramaIgnoreDuplicates(drama);
             throw new DuplicateTitleException(drama.getTitle() + "は、すでに登録されています。");
         }
         return drama;

--- a/src/main/java/com/raisetech/drama/service/DramasServiceImpl.java
+++ b/src/main/java/com/raisetech/drama/service/DramasServiceImpl.java
@@ -52,7 +52,12 @@ public class DramasServiceImpl implements DramasService{
         if (dramaDto.getPriority() != null) {
             drama.setPriority(dramaDto.getPriority());
         }
-        dramasMapper.update(drama);
+        try {
+            dramasMapper.update(drama);
+        } catch (DuplicateKeyException e) {
+            dramasMapper.updateDramaIgnoreDuplicates(drama);
+            throw new DuplicateTitleException(drama.getTitle() + "は、すでに登録されています。");
+        }
         return drama;
     }
 }


### PR DESCRIPTION
【変更内容】
・データベースのtitleカラムに一意制約を追加。
・POST処理時に一意制約違反が起こり、DuplicateKeyExceptionがスローされたときの例外ハンドリングを追加。
・PATCH処理時に一意制約違反が起こり、DuplicateKeyExceptionがスローされたときの例外ハンドリングを追加。

【変更目的】
同じタイトルのドラマを何度もメモする必要はないため。

【実行結果】
・[POST]すでに登録されているタイトルをリクエストしたとき
![image](https://github.com/Natsukotochobi/drama/assets/105856391/d0bc99ea-fcaf-45dd-a966-1573907330e1)
 
・[PATCH]すでに登録されているタイトルに変更しようとしたとき
![image](https://github.com/Natsukotochobi/drama/assets/105856391/762bc1c0-5c2a-4e21-af67-fea964de8588)

・[DB]テーブル構造
![image](https://github.com/Natsukotochobi/drama/assets/105856391/f548018b-152e-4863-a953-bcf87dae555f)
